### PR TITLE
Single image/labels/points layers support + tests

### DIFF
--- a/napari_hdf5_labels_io/__init__.py
+++ b/napari_hdf5_labels_io/__init__.py
@@ -4,4 +4,4 @@ except ImportError:
     __version__ = "unknown"
 
 from ._reader import h5_to_napari, reconstruct_layer
-from ._writer import project_to_h5, compress_layer
+from ._writer import project_to_h5, napari_write_image, napari_write_labels, napari_write_points

--- a/napari_hdf5_labels_io/_tests/test_reader.py
+++ b/napari_hdf5_labels_io/_tests/test_reader.py
@@ -1,6 +1,7 @@
 import numpy as np
 import h5py
-from napari_hdf5_labels_io import h5_to_napari, compress_layer
+from napari_hdf5_labels_io._reader import h5_to_napari
+from napari_hdf5_labels_io._writer import compress_layer
 
 
 # tmp_path is a pytest fixture

--- a/napari_hdf5_labels_io/_tests/test_writer.py
+++ b/napari_hdf5_labels_io/_tests/test_writer.py
@@ -1,3 +1,26 @@
-# from napari_hdf5_io import napari_get_writer, napari_write_image
+from napari_hdf5_labels_io._writer import write_layers_h5, layer_writer, compress_layer, process_metadata
+import numpy as np
+import os
 
-# add your tests here...
+test_meta = {'key1': 0, 'metadata': {'a': 0, 'b': 1}, 'key3': 2}
+test_layer_data = np.zeros((3,3))
+test_layer_data[1, 1] = 1
+
+def test_process_metadata():
+    out_dict = {'key1': 0, 'meta_a': 0, 'meta_b': 1, 'key3': 2}
+    assert process_metadata(test_meta) == out_dict
+
+
+def test_compress_layer():
+    out_data = np.array([[1], [1], [1]])
+    out_shape = (3, 3)
+    shape, data = compress_layer(test_layer_data)
+    assert out_shape == shape
+    assert all(data == out_data)
+
+def test_layer_writer(tmp_path):
+    test_single_data = {'key1': 0, 'metadata': {'a': 0, 'b': 1}, 'data': [1, 2, 3], 'name': 'label_1'}
+    out_path = str(tmp_path / 'test.h5')
+    out = layer_writer(out_path, test_layer_data, test_single_data, 'labels', sparse = True)
+    assert out == out_path
+    assert os.path.isfile(out_path)


### PR DESCRIPTION
This is a new version of the Napari IO plugin to include the functionality to save single Napari layers (image, labels and points). The new generated files are readable with the existing reading plugin.

These functions were tested with simple data and corresponding tests are included to achieve a coverage of 84%