### PR TITLE
Napari io package requirements update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ typing
 numpy
 numba==0.53.0rc1.post1
 sparse
-h5py
+h5py==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 napari-plugin-engine>=0.1.4
 typing
 numpy
-numba==0.53.0rc1.post1
 sparse
 h5py==2.10.0


### PR DESCRIPTION
specific numba not longer required and h5py 2.10.0  required to match tensorflow and yapic requirements.