### PR TITLE
Layer storage optimization

### DIFF
--- a/napari_hdf5_labels_io/_tests/test_reader.py
+++ b/napari_hdf5_labels_io/_tests/test_reader.py
@@ -18,6 +18,7 @@ def test_reader(tmp_path):
         label1 = labels.create_dataset('1abel1', data=compressed_data)
         label1.attrs['shape'] = original_shape
         label1.attrs['pos'] = 0
+        label1.attrs['compressed'] = True
 
     # try to read it back in
     reader = h5_to_napari(my_test_file)


### PR DESCRIPTION
In this request I changed the way label layers are stored in the HDF5 napari project file. Now the plugin will evaluate whether the label data is sparse enough to create a coordinates list of it, In case it is not sparse, it will store the original array to optimize the storage complexity. This pull request tries to solve #8 issue