### PR TITLE
changing the labels compression method to uint8, resolves issue 8

### DIFF
--- a/napari_hdf5_labels_io/_writer.py
+++ b/napari_hdf5_labels_io/_writer.py
@@ -145,7 +145,7 @@ def compress_layer(layer_array: np.array) -> tuple:
     tmp_coo = sparse.COO(layer_array)
     compressed_array = np.append(tmp_coo.coords, np.array(
         [tmp_coo.data]), axis=0)  # join coords and data in single array
-    return initial_shape, compressed_array.astype(np.int32)
+    return initial_shape, compressed_array.astype(np.uint8)
 
 
 def process_metadata(meta_dict: dict) -> dict:


### PR DESCRIPTION
The int32 compression is unnecessary since uint8 should be sufficient for storing the predictions while compression the labels.
resolves #8 